### PR TITLE
enhance/unify list access methods

### DIFF
--- a/lib/messages/data_structures/SmlList.js
+++ b/lib/messages/data_structures/SmlList.js
@@ -22,6 +22,18 @@ SmlList.prototype.addListEntry = function addListEntry(value){
 	this.listEntries[this.listEntries.length]=value;
 };
 
+SmlList.prototype.getListEntries = function getListEntries(){
+	return this.listEntries;
+};
+
+SmlList.prototype.getListEntryAt = function getListEntryAt(id){
+	return this.listEntries[id];
+};
+
+SmlList.prototype.getLength = function getLength(){
+	return this.listEntries.length;
+};
+
 SmlList.prototype.write = function write(buffer){
 	buffer.writeUInt8(0x70+this.listEntries.length); // SEQUENZ
 	for(var listEntry in this.listEntries){

--- a/lib/messages/data_structures/SmlPeriodList.js
+++ b/lib/messages/data_structures/SmlPeriodList.js
@@ -11,12 +11,20 @@ function SmlPeriodList(){
 	this.periodListEntries = [];
 }
 
-SmlPeriodList.prototype.addPeriodListEntry = function addPeriodListEntry(value){
+SmlPeriodList.prototype.addListEntry = function addListEntry(value){
 	this.periodListEntries[this.periodListEntries.length]=value;
 };
 
-SmlPeriodList.prototype.getPeriodListEntries = function getPeriodListEntries(){
+SmlPeriodList.prototype.getListEntries = function getListEntries(){
 	return this.periodListEntries;
+};
+
+SmlPeriodList.prototype.getListEntryAt = function getListEntryAt(id){
+	return this.periodListEntries[id];
+};
+
+SmlPeriodList.prototype.getLength = function getLength(){
+	return this.periodListEntries.length;
 };
 
 SmlPeriodList.prototype.getSize = function getSize(){
@@ -54,7 +62,7 @@ SmlPeriodList.parse = function parse(buffer){
 	}
 
 	for(var i=0; i<tlField.length; i++){
-		smlPeriodList.addPeriodListEntry(SmlPeriodListEntry.parse(buffer));
+		smlPeriodList.addListEntry(SmlPeriodListEntry.parse(buffer));
 	}
 
 	return smlPeriodList;

--- a/lib/messages/data_structures/SmlProfObjHeaderList.js
+++ b/lib/messages/data_structures/SmlProfObjHeaderList.js
@@ -29,6 +29,18 @@ SmlProfObjHeaderList.prototype.addListEntry = function addListEntry(value){
 	this.listEntries[this.listEntries.length]=value;
 };
 
+SmlProfObjHeaderList.prototype.getListEntries = function getListEntries(){
+	return this.listEntries;
+};
+
+SmlProfObjHeaderList.prototype.getListEntryAt = function getListEntryAt(id){
+	return this.listEntries[id];
+};
+
+SmlProfObjHeaderList.prototype.getLength = function getLength(){
+	return this.listEntries.length;
+};
+
 SmlProfObjHeaderList.prototype.toString = function toString(){
 	var str = "[\n";
 	for(var listEntry in this.listEntries){

--- a/lib/messages/data_structures/SmlProfObjPeriodList.js
+++ b/lib/messages/data_structures/SmlProfObjPeriodList.js
@@ -29,6 +29,18 @@ SmlProfObjPeriodList.prototype.addListEntry = function addListEntry(value){
 	this.listEntries[this.listEntries.length]=value;
 };
 
+SmlProfObjPeriodList.prototype.getListEntries = function getListEntries(){
+	return this.listEntries;
+};
+
+SmlProfObjPeriodList.prototype.getListEntryAt = function getListEntryAt(id){
+	return this.listEntries[id];
+};
+
+SmlProfObjPeriodList.prototype.getLength = function getLength(){
+	return this.listEntries.length;
+};
+
 SmlProfObjPeriodList.prototype.toString = function toString(){
 	var str = "[\n";
 	for(var listEntry in this.listEntries){

--- a/lib/messages/data_structures/SmlTreeList.js
+++ b/lib/messages/data_structures/SmlTreeList.js
@@ -27,6 +27,18 @@ SmlTreeList.prototype.addListEntry = function addListEntry(value){
 	this.listEntries[this.listEntries.length]=value;
 };
 
+SmlTreeList.prototype.getListEntries = function getListEntries(){
+	return this.listEntries;
+};
+
+SmlTreeList.prototype.getListEntryAt = function getListEntryAt(id){
+	return this.listEntries[id];
+};
+
+SmlTreeList.prototype.getLength = function getLength(){
+	return this.listEntries.length;
+};
+
 SmlTreeList.prototype.toString = function toString(){
 	var str = "[\n";
 	for(var listEntry in this.listEntries){

--- a/lib/messages/data_structures/SmlValueList.js
+++ b/lib/messages/data_structures/SmlValueList.js
@@ -30,6 +30,18 @@ SmlValueList.prototype.addListEntry = function addListEntry(value){
 	this.listEntries[this.listEntries.length]=value;
 };
 
+SmlValueList.prototype.getListEntries = function getListEntries(){
+	return this.listEntries;
+};
+
+SmlValueList.prototype.getListEntryAt = function getListEntryAt(id){
+	return this.listEntries[id];
+};
+
+SmlValueList.prototype.getLength = function getLength(){
+	return this.listEntries.length;
+};
+
 SmlValueList.prototype.toString = function toString(){
 	var str = "[\n";
 	for(var listEntry in this.listEntries){

--- a/test/TestSmlFileWrite.js
+++ b/test/TestSmlFileWrite.js
@@ -59,7 +59,7 @@ smlFile.addMessage(smlMessage1);
 	periodListEntry.setValue(1252);
 	periodListEntry.setValueType(sml.Constants.INT16);
 	//periodListEntry.setValueSignature();
-	periodList.addPeriodListEntry(periodListEntry);
+	periodList.addListEntry(periodListEntry);
 
 	var periodListEntry = new sml.SmlPeriodListEntry();
 	periodListEntry.setObjName("0100010801ff");
@@ -68,7 +68,7 @@ smlFile.addMessage(smlMessage1);
 	periodListEntry.setValue(1252);
 	periodListEntry.setValueType(sml.Constants.INT16);
 	//periodListEntry.setValueSignature();
-	periodList.addPeriodListEntry(periodListEntry);
+	periodList.addListEntry(periodListEntry);
 
 	var periodListEntry = new sml.SmlPeriodListEntry();
 	periodListEntry.setObjName("0100100700ff");
@@ -77,7 +77,7 @@ smlFile.addMessage(smlMessage1);
 	periodListEntry.setValue(523);
 	periodListEntry.setValueType(sml.Constants.INT16);
 	//periodListEntry.setValueSignature();
-	periodList.addPeriodListEntry(periodListEntry);
+	periodList.addListEntry(periodListEntry);
 
 	var periodListEntry = new sml.SmlPeriodListEntry();
 	periodListEntry.setObjName("0100010802ff");
@@ -86,7 +86,7 @@ smlFile.addMessage(smlMessage1);
 	periodListEntry.setValue(986);
 	periodListEntry.setValueType(sml.Constants.INT16);
 	//periodListEntry.setValueSignature();
-	periodList.addPeriodListEntry(periodListEntry);
+	periodList.addListEntry(periodListEntry);
 
 	smlGetProfileListResponse.setPeriodList(periodList);
 	//smlGetProfileListResponse.setRawdata();


### PR DESCRIPTION
As really using the library to read SML data and use the contained
details I found missing access methods and also I found that
„PeriodList“ used different wording. In my eyes its more convenient and
easy to use if the usage methods for the various list methods are equal.